### PR TITLE
(SIMP-5032) Fix logic bug in simp-vendored-r10k spec file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,10 @@
-* Wed Apr 18 2018 Nick Miller <nick.miller@onyxpoint.com> - 2.6.2
+* Tue Jul 17 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 2.6.2-1
+- Fixed bug in RPM variable used in simp-vendored-r10k description
+- Fixed bug in which release for r01k gem in sources.yaml was not being
+  used for the RPM release number of simp-vendored-r10k and
+  simp-vendored-r10k-doc packages.
+
+* Wed Apr 18 2018 Nick Miller <nick.miller@onyxpoint.com> - 2.6.2-0
 - Update rpm to include r10k 2.6.2 and other components.
 - Gems are now built from source and not contained in the repo.
   See build/sources.yaml.

--- a/Gemfile
+++ b/Gemfile
@@ -31,4 +31,8 @@ group :testing do
   # Testing framework
   gem 'rspec'
   gem 'rspec-its'
+
+  # A dependency of simp-rake-helpers
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.10.8', '< 2.0'])
+
 end

--- a/Rakefile
+++ b/Rakefile
@@ -128,6 +128,7 @@ namespace :pkg do
   desc 'Build the rpms for all gems in the build/sources.yaml file'
   task :rpm => :rpmspec do
     version  = deps['version']
+    release  = deps['gems']['r10k']['release'].nil? ? 0 : deps['gems']['r10k']['release']
     builddir = File.join('dist','RPMBUILD')
 
     FileUtils.mkdir_p 'dist'
@@ -142,7 +143,7 @@ namespace :pkg do
       tar_cmd << "--exclude=simp-vendored-r10k-#{version}/vendor"
       tar_cmd << "--exclude=simp-vendored-r10k-#{version}/.bundle"
       tar_cmd << '-czf'
-      tar_cmd << "../RPMBUILD/SOURCES/simp-vendored-r10k-#{version}-0.tar.gz"
+      tar_cmd << "../RPMBUILD/SOURCES/simp-vendored-r10k-#{version}-#{release}.tar.gz"
       tar_cmd << "simp-vendored-r10k-#{version}"
       sh tar_cmd.join(' ')
     end

--- a/build/simp-vendored-r10k.spec.erb
+++ b/build/simp-vendored-r10k.spec.erb
@@ -13,7 +13,7 @@
 Summary: r10k with puppet-safe gem installation
 Name: simp-vendored-r10k
 Version: %{r10k_version}
-Release: 0
+Release: <%= deps['gems']['r10k']['release'] || 0 %>
 Group: Development/Languages
 License: Apache-2.0
 URL: https://github.com/simp/pkg-r10k
@@ -37,13 +37,13 @@ will also work.
 This was specifically designed for situations where Internet access is
 difficult or unattainable.
 
-Binaries from this package will be located at %{simp_binpath} and will not be
+Binaries from this package will be located at %{simp_bindir} and will not be
 in your path by default.
 
 %package doc
 Summary: Documentation for the SIMP r10k installation
 Version: %{r10k_version}
-Release: 0
+Release: <%= deps['gems']['r10k']['release'] || 0 %>
 License: Apache-2.0
 URL: https://github.com/simp/pkg-r10k
 BuildArch: noarch

--- a/build/sources.yaml
+++ b/build/sources.yaml
@@ -70,6 +70,7 @@ gems:
     version: 2.6.2
     license: Apache-2.0
     url: https://github.com/puppetlabs/r10k
+    release: 1
   semantic_puppet:
     version: 1.0.2
     license: Apache-2.0


### PR DESCRIPTION
- Fixed bug in RPM variable used in simp-vendored-r10k description.
- Fixed bug in which release for r01k gem in sources.yaml was not being
  used for the RPM release number of simp-vendored-r10k and
  simp-vendored-r10k-doc packages.

SIMP-5032 #close