### PR TITLE
(SIMP-8797) Disable Travis CI tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,6 +113,13 @@ variables:
   tags: ['beaker']
   <<: *setup_bundler_env
 
+pkg_rpm:
+  stage: 'validation'
+  tags: ['rpmbuild']
+  <<: *setup_bundler_env
+  script:
+    - 'bundle exec rake pkg:rpm'
+    - 'bundle exec rake clean'
 
 # Pipeline / testing matrix
 #=======================================================================

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,6 @@ variables:
     - 'bundle exec rake lint'
     - 'bundle exec rake metadata_lint'
 
-
 .acceptance_base: &acceptance_base
   stage: 'acceptance'
   tags: ['beaker']
@@ -119,6 +118,8 @@ pkg_rpm:
   <<: *pup_6
   <<: *setup_bundler_env
   script:
+    - 'if `hash apt-get`; then apt-get update; fi'
+    - 'if `hash apt-get`; then apt-get install -y rpm; fi'
     - 'bundle exec rake pkg:rpm'
     - 'bundle exec rake clean'
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,6 +116,7 @@ variables:
 pkg_rpm:
   stage: 'validation'
   tags: ['rpmbuild']
+  <<: *pup_6
   <<: *setup_bundler_env
   script:
     - 'bundle exec rake pkg:rpm'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ cache: bundler
 sudo: false
 
 stages:
-  - check
-  - spec
+  ###  - check
+  ###  - spec
   - name: deploy
     if: 'tag IS present'
 
@@ -13,32 +13,28 @@ bundler_args: --without development system_tests --path .vendor
 notifications:
   email: false
 
-addons:
-  apt:
-    packages:
-      - rpm
-
 rvm:
   - 2.4.4
 
-before_install:
-  - rm -f Gemfile.lock
-  - gem install -v '~> 1.16.0' bundler
-  - gem list bundler
-
 jobs:
   include:
-    - stage: check
-      script:
-        - bundle exec rake pkg:create_tag_changelog
-
-    - stage: spec
-      sudo: required
-      services:
-        - docker
-      script:
-        - bundle exec rake pkg:rpm
-        - bundle exec rake clean
+    ###  Testing on Travis CI is indefinitely disabled
+    ###
+    ###  See:
+    ###    * https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
+    ###    * https://simp-project.atlassian.net/browse/SIMP-8703
+    ###
+    ###    - stage: check
+    ###      script:
+    ###        - bundle exec rake pkg:create_tag_changelog
+    ###
+    ###    - stage: spec
+    ###      sudo: required
+    ###      services:
+    ###        - docker
+    ###      script:
+    ###        - bundle exec rake pkg:rpm
+    ###        - bundle exec rake clean
 
     - stage: deploy
       script:


### PR DESCRIPTION
This patch disables ALL TESTS in modules' Travis CI pipelines.
Deployment and diagnostic stages have been left to support near-term
releases, however we will shortly migrate them elsewhere as well.

The `pkg:rpm` validation step has been moved into the GitLab CI
pipeline.

[SIMP-8797] #close

[SIMP-8797]: https://simp-project.atlassian.net/browse/SIMP-8797