### PR TITLE
(SIMP-8441) Update r10k to 3.7.0 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,6 +113,13 @@ variables:
   tags: ['beaker']
   <<: *setup_bundler_env
 
+pkg_rpm:
+  stage: 'validation'
+  tags: ['rpmbuild']
+  <<: *setup_bundler_env
+  script:
+    - 'bundle exec rake pkg:rpm'
+    - 'bundle exec rake clean'
 
 # Pipeline / testing matrix
 #=======================================================================

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,8 +132,7 @@ sanity_checks:
   script:
 # The puppet gem is used by one of the scripts in this
 # project, but puppet module checks are inapplicable
-    - 'if `hash apt-get`; then apt-get update; fi'
-    - 'if `hash apt-get`; then apt-get install -y rpm; fi'
+    - 'command -v rpm || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
 #    - 'bundle exec rake check:dot_underscore'
 #    - 'bundle exec rake check:test_file'
 #    - 'bundle exec rake pkg:check_version'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,20 +1,10 @@
-# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
-#
-# https://puppet.com/docs/pe/2018.1/component_versions_in_recent_pe_releases.html
-# https://puppet.com/misc/puppet-enterprise-lifecycle
-# https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
-# ------------------------------------------------------------------------------
-# Release       Puppet   Ruby   EOL
-# PE 2017.3.10  5.3.8    2.4.4  2018-12 (STS)
-# SIMP 6.3      5.5.7    2.4.4  TBD***
-# PE 2018.1     5.5.6    2.4.4  2020-05 (LTS)***
-# PE 2019.0     6.0      2.5.1  2019-08-31^^^
-#
-# *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
-# ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
+# The testing matrix considers ruby/puppet versions supported by SIMP:
+# --------------------------------------------------------------------
+# Release       Puppet   Ruby    EOL
+# SIMP 6.4      5.5      2.4.10  TBD
+# SIMP 6.5      6.18     2.4.10  TBD
 ---
 stages:
-  - 'sanity'
   - 'validation'
   - 'acceptance'
   - 'compliance'
@@ -66,31 +56,17 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_5: &pup_5
-  image: 'ruby:2.4'
-  variables:
-    PUPPET_VERSION: '~> 5.0'
-    BEAKER_PUPPET_COLLECTION: 'puppet5'
-    MATRIX_RUBY_VERSION: '2.4'
-
-.pup_5_3: &pup_5_3
-  image: 'ruby:2.4'
-  variables:
-    PUPPET_VERSION: '~> 5.3.0'
-    BEAKER_PUPPET_COLLECTION: 'puppet5'
-    MATRIX_RUBY_VERSION: '2.4'
-
-.pup_5_5_10: &pup_5_5_10
+.pup_5_5_20: &pup_5_5_20
   image: 'ruby:2.5'
   variables:
-    PUPPET_VERSION: '5.5.10'
+    PUPPET_VERSION: '5.5.20'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.5'
 
-.pup_6: &pup_6
+.pup_6_18: &pup_6_18
   image: 'ruby:2.5'
   variables:
-    PUPPET_VERSION: '~> 6.0'
+    PUPPET_VERSION: '~> 6.18.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
@@ -115,7 +91,7 @@ variables:
 pkg_rpm:
   stage: 'validation'
   tags: ['rpmbuild']
-  <<: *pup_6
+  <<: *pup_6_18
   <<: *setup_bundler_env
   script:
     - 'command -v rpmbuild || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
@@ -127,90 +103,52 @@ pkg_rpm:
 # Pipeline / testing matrix
 #=======================================================================
 
-sanity_checks:
+releng_checks:
   <<: *pup_5
   <<: *setup_bundler_env
-  stage: 'sanity'
+  stage: 'validation'
   tags: ['docker']
   script:
-# The puppet gem is used by one of the scripts in this
-# project, but puppet module checks are inapplicable
     - 'command -v rpm || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
     - 'command -v rpm || { >&2 echo "FATAL: Cannot find executable: ''rpm''";  exit 1 ;}'
-#    - 'bundle exec rake check:dot_underscore'
-#    - 'bundle exec rake check:test_file'
-#    - 'bundle exec rake pkg:check_version'
-#    - 'bundle exec rake pkg:compare_latest_tag'
     - 'bundle exec rake pkg:create_tag_changelog'
-#    - 'bundle exec puppet module build'
 
-# Linting
-#-----------------------------------------------------------------------
-
-# puppet module lint checks are inapplicable
-#
-#pup5-lint:
-#  <<: *pup_5
-#  <<: *lint_tests
-#
-#pup6-lint:
-#  <<: *pup_6
-#  <<: *lint_tests
-
-# Unit Tests
-#-----------------------------------------------------------------------
-
-#pup5-unit:
-#  <<: *pup_5
-#  <<: *unit_tests
-#
-#pup5.3-unit:
-#  <<: *pup_5_3
-#  <<: *unit_tests
-
-#pup5.5.7-unit:
-#  <<: *pup_5_5_7
-#  <<: *unit_tests
-
-#pup6-unit:
-#  <<: *pup_6
-#  <<: *unit_tests
 
 # Acceptance tests
 # ==============================================================================
 
-pup5.5.10:
-  <<: *pup_5_5_10
+pup5.5.20:
+  <<: *pup_5_5_20
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites'
     - 'bundle exec rake beaker:suites[upgrade,default]'
 
-pup6:
-  <<: *pup_6
+pup6.18:
+  <<: *pup_6_18
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites'
     - 'bundle exec rake beaker:suites[upgrade,default]'
 
-pup5.5.10-fips:
-  <<: *pup_5_5_10
+pup5.5.20-fips:
+  <<: *pup_5_5_20
   <<: *acceptance_base
   <<: *only_with_SIMP_FULL_MATRIX
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites'
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[upgrade,default]'
 
-pup5.5.10-oel:
-  <<: *pup_5_5_10
+pup5.5.20-oel:
+  <<: *pup_5_5_20
   <<: *acceptance_base
   <<: *only_with_SIMP_FULL_MATRIX
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
     - 'bundle exec rake beaker:suites[upgrade,oel]'
 
-pup5.5.10-oel-fips:
-  <<: *pup_5_5_10
+pup5.5.20-oel-fips:
+  <<: *pup_5_5_20
   <<: *acceptance_base
   <<: *only_with_SIMP_FULL_MATRIX
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,7 +104,7 @@ pkg_rpm:
 #=======================================================================
 
 releng_checks:
-  <<: *pup_5
+  <<: *pup_5_5_20
   <<: *setup_bundler_env
   stage: 'validation'
   tags: ['docker']

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ cache: bundler
 sudo: false
 
 stages:
-  - check
-  - spec
+  ###  - check
+  ###  - spec
   - name: deploy
     if: 'tag IS present'
 
@@ -13,32 +13,28 @@ bundler_args: --without development system_tests --path .vendor
 notifications:
   email: false
 
-addons:
-  apt:
-    packages:
-      - rpm
-
 rvm:
   - 2.4.4
 
-before_install:
-  - rm -f Gemfile.lock
-  - gem install -v '~> 1.16.0' bundler
-  - gem list bundler
-
 jobs:
   include:
-    - stage: check
-      script:
-        - bundle exec rake pkg:create_tag_changelog
-
-    - stage: spec
-      sudo: required
-      services:
-        - docker
-      script:
-        - bundle exec rake pkg:rpm
-        - bundle exec rake clean
+    ###  Testing on Travis CI is indefinitely disabled
+    ###
+    ###  See:
+    ###    * https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
+    ###    * https://simp-project.atlassian.net/browse/SIMP-8703
+    ###
+    ###    - stage: check
+    ###      script:
+    ###        - bundle exec rake pkg:create_tag_changelog
+    ###
+    ###    - stage: spec
+    ###      sudo: required
+    ###      services:
+    ###        - docker
+    ###      script:
+    ###        - bundle exec rake pkg:rpm
+    ###        - bundle exec rake clean
 
     - stage: deploy
       script:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,22 @@
+* Wed Dec 09 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.7.0-0
+- Changed:
+  - Updated source versions to use r10k 3.7.0 and its corresponding
+    gem dependencies
+  - The `colored` gem has been deprecated in favor of `colored2`
+- Fixed:
+  - Fixed `rake gem_update` to (mostly) correctly update `build/sources.yaml`
+- Added:
+  - Project README.md
+  - Enhancements to `rake gem_update`:
+    - Resolves r10k gem dependencies from the r10k gem on rubygems.org
+    - Updates version, url, repo, and license
+    - When it can't safely update a url, it will print a warning (helpful because log4r is a
+    - Adds new gem deps, removes old ones
+  - Enhancements to `rake pkg:gem`:
+    - Hack for git clone of untagged `log4r` release
+  - Removed:
+    - Old hacks for `colored` gem
+
 * Mon Jun 24 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.3.0-0
 - Updated source versions to use r10k 3.3.0 and its corresponding
   gem dependencies
@@ -14,7 +33,7 @@
 - Updated the version of simp-rake-helpers in Gemfile
   because earlier version has r10k dependency set to ~> 2.2.
 - Updated release for all dependencies so they would all be reinstalled
-  in the new simp-r10k directory.  Gem dependencies were being installed 
+  in the new simp-r10k directory.  Gem dependencies were being installed
   in r10k-<version> directory.  If r10k was
   updated it create a new r10k-<version> directory but if dependencies had
   not been updated they were not reinstalled in new directory. To fix this

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
   - The `colored` gem has been deprecated in favor of `colored2`
 - Fixed:
   - Fixed `rake gem_update` to (mostly) correctly update `build/sources.yaml`
+  - Re-enabled the simp community repo in acceptance tests
 - Added:
   - Project README.md
   - Enhancements to `rake gem_update`:

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'rake'
 gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '>= 5.8.1')
 
 gem 'r10k', ENV.fetch('R10K_VERSION', '3.1.1')
+gem 'rest-client'
 
 group :testing do
   # bootstrap common environment variables

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+## pkg-r10k: simp-vendored R10K gem-to-RPMs packager
+
+#### Table of Contents
+
+<!-- vim-markdown-toc GFM -->
+
+* [Description](#description)
+* [Setup](#setup)
+  * [Requirements](#requirements)
+  * [Getting started](#getting-started)
+* [Usage](#usage)
+
+<!-- vim-markdown-toc -->
+
+## Description
+
+This project builds a SIMP-vendored RPM of [r10k], which is intended to ensure that a known
+version of r10k is present on the system.
+
+* The build process creates RPMs for the r10k gem and each of its dependencies.
+* The `r10k` executable is installed into `/usr/share/simp/bin/r10k`
+
+
+## Setup
+
+### Requirements
+
+* [Ruby] (last tested with 2.4.9 and 2.5.7)
+* [bundler]
+
+### Getting started
+
+```sh
+git clone https://github.com/simp/pkg-r10k
+cd pkg-r10k
+bundle install
+bundle exec rake -T
+```
+
+## Usage
+
+To update to the latest version of r10k and package all its gems:
+
+1. Update `build/sources.yaml` to the latest version of r10k
+
+   ```sh
+   bundle exec rake gem_update
+   ```
+
+   To review the changes:
+
+   ```sh
+   git diff build/sources.yaml
+   ```
+
+2. Verify that the data in `build/sources.yaml` is correct
+
+3. Check out gems and build RPMs using the data in `build/sources.yaml`
+
+   ```sh
+   bundle exec rake pkg:rpm
+   ```
+
+   The RPMs will be built under the `dist/` directory.
+
+[r10k]: https://github.com/puppetlabs/r10k
+[ruby]: https://www.ruby-lang.org/
+[bundler]: https://bundler.io

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ version of r10k is present on the system.
 
 * The build process creates RPMs for the r10k gem and each of its dependencies.
 * The `r10k` executable is installed into `/usr/share/simp/bin/r10k`
-
+* Tested against Puppet 5.5 and Puppet 6
 
 ## Setup
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ require 'yaml'
 require 'rest-client'
 
 pkg = Simp::Rake::Pkg.new(File.dirname(__FILE__))
-# Simp::RakePkg decides where the RPM spec file for a project is in
+# Simp::Rake::Pkg decides where the RPM spec file for a project is in
 # its constructor.  However, for this project, the spec file will be
 # generated.  So need to tell it where the spec file will be found.
 pkg.spec_file = File.join(File.dirname(__FILE__), 'build', 'simp-vendored-r10k.spec')

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require 'simp/rake'
 require 'simp/rake/beaker'
 require 'erb'
 require 'yaml'
+require 'rest-client'
 
 pkg = Simp::Rake::Pkg.new(File.dirname(__FILE__))
 # Simp::RakePkg decides where the RPM spec file for a project is in
@@ -28,6 +29,7 @@ Find.find( @rakefile_dir ) do |path|
   end
 end
 
+desc 'Check out each r10k gem repository (uses build/sources.yaml)'
 task :checkout do
   deps['gems'].each do |gem,data|
     FileUtils.mkdir_p 'src/gems'
@@ -42,19 +44,109 @@ task :checkout do
       end
 
       Dir.chdir(gem) do
-        `git fetch -q`
-        `git checkout -q #{data['version']} 2> /dev/null`
-        `git checkout -q v#{data['version']} 2> /dev/null`
+        sh 'git fetch -q'
+        checkout_attempts = [
+          "git checkout -q #{data['version']} 2> /dev/null",
+          "git checkout -q v#{data['version']} 2> /dev/null",
+        ]
+
+        # The log4r github repo doesn't have any tags, and its last release
+        # (1.1.10) was in 2012.  However, the master branch has accumulated
+        # many more commits over the years (and some of them may have been
+        # breaking changes: https://github.com/colbygk/log4r/issues/26)
+        if data['repo'] == 'https://github.com/colbygk/log4r' && data['version'] == '1.1.10'
+          # This is the commit the released log4r 1.1.10 gem was built from
+          checkout_attempts << 'git checkout -q 40e2c2edd657a21b34f09dec7de238f348b6f428 2> /dev/null'
+        end
+
+        sh checkout_attempts.join(' || ')
       end
     end
   end
 end
 
-task :gem_update do
-  deps['gems'].each do |gem,data|
-    data['version'] = Gem.latest_spec_for(gem).version.to_s
+def sanitize_github_repo_uri(str)
+  return unless (str =~ %r{\Ahttps?://github.com/})
+  res = str.dup
+  res.sub!(%r{\Ahttp:},'https:')
+  res.sub!(%r{(https://github.com/[^/]+/[^/]+)/.*}, '\1')
+  res.sub!(%r{/\Z},'')
+  res
+end
+
+desc <<~DESC
+  Update gems in build/sources.yaml to latest available versions
+
+  This task will
+DESC
+task :gem_update, [:r10k_version] do |_t, args|
+  version = args.with_defaults(r10k_version: nil)
+  new_deps = Marshal.load(Marshal.dump(deps))
+  require 'tmpdir'
+  require 'rubygems/remote_fetcher' # needed this with Ruby 2.5
+  require 'rubygems/name_tuple'     # needed this w/2.4 & 2.5
+  dep = Gem::Dependency.new 'r10k', version
+  set = Gem::RequestSet.new dep
+  requests = set.resolve
+
+  removed_gems = deps['gems'].keys - (requests.map{|r| r.name })
+  removed_gems.each do |g|
+      warn ''
+      warn '!'*80
+      warn "WARNING: **REMOVING GEM** (no longer required): '#{g}'"
+      warn '!'*80
+      new_deps['gems'].delete(g)
   end
-  File.write('build/sources.yaml', deps.to_yaml)
+
+  new_gems = []
+  updated_gems = []
+  requests.each do |r|
+    data = nil
+    data = new_deps['gems'][r.name] ||= {}
+
+    if data.empty?
+      warn '', '='*80, "WARNING: **NEW GEM** dependency found: '#{r.name}'", '='*80
+    end
+
+    data['release'] = (r.version.to_s == data['version'].to_s) ? data['release'] + 1 : 0
+    data['version'] = r.version.to_s
+
+    Gem.sources.to_a.each do |gem_src|
+      url = "#{gem_src}/api/v2/rubygems/#{r.name}/versions/#{r.version}.json"
+      j = RestClient.get url, {content_type: :json, accept: :json}
+      api_data = JSON.parse(j)
+      if api_data['licenses'] && api_data['licenses'] != data['license'].to_s
+        data['license'] = api_data['licenses'].join(' or ')
+      end
+      data['license'] ||= 'UNKNOWN'
+
+      if api_data['source_code_uri']
+        a_uri = sanitize_github_repo_uri(api_data['source_code_uri'])
+        g_uri = sanitize_github_repo_uri(data['repo'])
+
+        unless a_uri == g_uri
+          warn ''
+          warn "'#{r.name}' gem repo source_code_uri is different than 'repo' URL in 'build/sources.yaml'"
+          warn "              File: #{data['repo']}"
+          warn "              Gem:  #{api_data['source_code_uri']}"
+          warn "         CHECK MANUALLY!  (Keeping the old version in case the gem version is nonsense)"
+        else
+          data['repo'] = a_uri
+        end
+      end
+
+      if (data['repo'] && r.full_spec.homepage != data['url']) || (!data['url'])
+        data['url'] = r.full_spec.homepage
+      end
+
+      if data['url'] && !data['repo']
+        data['repo'] ||= sanitize_github_repo_uri(data['url'])
+      end
+    end
+  end
+
+  new_deps['version'] = new_deps['gems']['r10k']['version']
+  File.write('build/sources.yaml', new_deps.to_yaml)
 end
 
 task :rpms_present do
@@ -74,10 +166,6 @@ namespace :pkg do
       Dir.chdir("src/gems/#{gem}") do |d|
         # multi_json requires a signing key, we don't have one
         sh "sed -i '/signing_key/d' #{gem}.gemspec" if gem == 'multi_json'
-        # this is a very old gem and newer versions of rubygems require a LICENSE
-        # the master branch has one but there will be no new release
-        sh 'curl -s https://raw.githubusercontent.com/defunkt/colored/master/LICENSE > LICENSE' if gem == 'colored'
-
         `gem build --silent #{gem}.gemspec`
         FileUtils.mkdir_p 'dist'
         FileUtils.mv Dir.glob('*.gem'), File.join(@rakefile_dir, 'dist')

--- a/build/sources.yaml
+++ b/build/sources.yaml
@@ -1,92 +1,100 @@
 ---
-version: 3.3.0
+version: 3.7.0
 url: https://github.com/simp/pkg-r10k
-# gathered with:
-# `gem install r10k --install-dir /tmpdir --version 3.3.0`
-# `ls /tmpdir`
-#
-# NOTE:  If a gem version has not changed, bump the release
-#        number, so that a new RPM that installs into
-#        a subdirectory under the r10k version is generated.
 gems:
-  colored:
-    version: '1.2'
-    license: MIT
-    url: https://github.com/defunkt/colored
-    release: 3
   cri:
-    version: '2.15.6'
+    version: 2.15.10
     license: MIT
     url: https://github.com/ddfreyne/cri
+    repo: https://github.com/ddfreyne/cri
     release: 0
   faraday:
-    version: '0.13.1'
+    version: 0.17.3
     license: MIT
-    url: https://github.com/lostisland/faraday
+    url: https://lostisland.github.io/faraday
+    repo: https://github.com/lostisland/faraday
     release: 0
   faraday_middleware:
-    version: '0.12.2'
+    version: 0.14.0
     license: MIT
     url: https://github.com/lostisland/faraday_middleware
+    repo: https://github.com/lostisland/faraday_middleware
     release: 0
   fast_gettext:
-    version: '1.1.2'
-    license: MIT
-    url: https://github.com/grosser/fast_gettext
-    release: 2
+    version: 1.1.2
+    license: MIT or Ruby
+    url: http://github.com/grosser/fast_gettext
+    repo: https://github.com/grosser/fast_gettext
+    release: 3
   gettext:
     version: 3.2.9
     license: Ruby or LGPLv3+
-    url: https://github.com/ruby-gettext/gettext
-    release: 2
+    url: http://ruby-gettext.github.com/
+    repo: https://github.com/ruby-gettext/gettext
+    release: 3
   gettext-setup:
-    version: '0.30'
+    version: '0.34'
     license: Apache-2.0
     url: https://github.com/puppetlabs/gettext-setup-gem
-    release: 2
+    repo: https://github.com/puppetlabs/gettext-setup-gem
+    release: 0
   locale:
-    version: '2.1.2'
+    version: 2.1.3
     license: Ruby or LGPLv3+
     url: https://github.com/ruby-gettext/locale
-    release: 2
+    repo: https://github.com/ruby-gettext/locale
+    release: 0
   log4r:
-    version: '1.1.10'
+    version: 1.1.10
     license: MIT
     url: http://log4r.rubyforge.org
     repo: https://github.com/colbygk/log4r
-    release: 3
+    release: 4
   minitar:
-    version: '0.8'
-    license: Ruby
+    version: '0.9'
+    license: Ruby or BSD-2-Clause
     url: https://github.com/halostatue/minitar/
+    repo: https://github.com/halostatue/minitar
     release: 0
   multi_json:
-    version: '1.13.1'
+    version: 1.15.0
     license: MIT
     url: https://github.com/intridea/multi_json
+    repo: https://github.com/intridea/multi_json
     release: 0
   multipart-post:
-    version: '2.1.1'
+    version: 2.1.1
     license: MIT
     url: https://github.com/nicksieger/multipart-post
-    release: 1
+    repo: https://github.com/nicksieger/multipart-post
+    release: 2
   puppet_forge:
-    version: '2.2.9'
-    license: MIT
+    version: 2.3.4
+    license: Apache-2.0
     url: https://github.com/puppetlabs/forge-ruby
+    repo: https://github.com/puppetlabs/forge-ruby
     release: 0
   r10k:
-    version: '3.3.0'
+    version: 3.7.0
     license: Apache-2.0
     url: https://github.com/puppetlabs/r10k
+    repo: https://github.com/puppetlabs/r10k
     release: 0
   semantic_puppet:
-    version: '1.0.2'
+    version: 1.0.2
     license: Apache-2.0
     url: https://github.com/puppetlabs/semantic_puppet
-    release: 2
+    repo: https://github.com/puppetlabs/semantic_puppet
+    release: 3
   text:
-    version: '1.3.1'
+    version: 1.3.1
     license: MIT
     url: http://github.com/threedaymonk/text
-    release: 2
+    repo: http://github.com/threedaymonk/text
+    release: 3
+  colored2:
+    release: 0
+    version: 3.1.2
+    license: MIT
+    url: http://github.com/kigster/colored2
+    repo: https://github.com/kigster/colored2

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -6,15 +6,6 @@
   end
 -%>
 HOSTS:
-  el6:
-    roles:
-      - server
-      - default
-      - master
-      - client
-    platform: el-6-x86_64
-    box: centos/6
-    hypervisor: <%= hypervisor %>
   el7:
     roles:
       - client
@@ -31,7 +22,7 @@ CONFIG:
   if ENV['BEAKER_PUPPET_COLLECTION']
     puppet_env = ENV['BEAKER_PUPPET_COLLECTION']
   else
-    puppet_env = 'puppet5'
+    puppet_env = 'puppet6'
   end
 %>
 puppet_collection:  <%= puppet_env %>

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -6,15 +6,6 @@
   end
 -%>
 HOSTS:
-  el6:
-    roles:
-      - server
-      - default
-      - master
-      - client
-    platform: el-6-x86_64
-    box: onyxpoint/oel-6-x86_64
-    hypervisor: <%= hypervisor %>
   el7:
     roles:
       - client

--- a/spec/acceptance/suites/upgrade/upgrade_r10k_spec.rb
+++ b/spec/acceptance/suites/upgrade/upgrade_r10k_spec.rb
@@ -22,7 +22,7 @@ def install_deps(host, osver)
 end
 
 def simp_deps_repo(host)
-  install_simp_repos(host, ['simp'])
+  install_simp_repos(host, ['simp_deps'])
   on(host, 'yum makecache')
 end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -6,10 +6,6 @@ include Simp::BeakerHelpers
 
 unless ENV['BEAKER_provision'] == 'no'
   hosts.each do |host|
-    # Install system ruby, as some of simp-utils scripts
-    # use system ruby
-    host.install_package('ruby')
-
     # Install Puppet
     # Acceptance tests need puppet in order to turn FIPS mode on
     if host.is_pe?


### PR DESCRIPTION
This commit updates the build sources to use r10k 3.7.0.

It also:
* Overhauls the `check_update` Rake task (so it actually works) 
* Adds a project README.md.
* Updates the GLCI pipeline to the latest versions
* Removes EL6 from acceptance tests + nodesets
* Fixes a simp community repo bug in the acceptance tests

[SIMP-8441] #close
[SIMP-8834] #close #comment Remove EL6 from tests + nodesets

[SIMP-8441]: https://simp-project.atlassian.net/browse/SIMP-8441

[SIMP-8834]: https://simp-project.atlassian.net/browse/SIMP-8834