### PR TITLE
(SIMP-10445) simp vendored r10k failing on EL8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
-.pup_7_x: &pup_7_x
+.pup_7_x: &pup_7_X
   image: 'ruby:2.7'
   variables:
     PUPPET_VERSION: '~> 7.0'
@@ -120,14 +120,14 @@ pup_6_X:
   <<: *pup_6_X
   <<: *acceptance_base
   script:
-    - 'bundle exec rake beaker:suites'
+    - 'bundle exec rake beaker:suites[default,default]'
     - 'bundle exec rake beaker:suites[upgrade,default]'
 
 pup_7_X:
   <<: *pup_7_X
   <<: *acceptance_base
   script:
-    - 'bundle exec rake beaker:suites'
+    - 'bundle exec rake beaker:suites[default,default]'
     - 'bundle exec rake beaker:suites[upgrade,default]'
 
 pup6-fips:
@@ -135,7 +135,7 @@ pup6-fips:
   <<: *acceptance_base
   <<: *only_with_SIMP_FULL_MATRIX
   script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[upgrade,default]'
 
 pup6-oel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,20 +56,19 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_5_5_20: &pup_5_5_20
+.pup_6_X: &pup_6_X
   image: 'ruby:2.5'
   variables:
-    PUPPET_VERSION: '5.5.20'
-    BEAKER_PUPPET_COLLECTION: 'puppet5'
-    MATRIX_RUBY_VERSION: '2.5'
-
-.pup_6_18: &pup_6_18
-  image: 'ruby:2.5'
-  variables:
-    PUPPET_VERSION: '~> 6.18.0'
+    PUPPET_VERSION: '~> 6.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
+.pup_7_x: &pup_7_x
+  image: 'ruby:2.7'
+  variables:
+    PUPPET_VERSION: '~> 7.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet7'
+    MATRIX_RUBY_VERSION: '2.7'
 
 # Testing Environments
 #-----------------------------------------------------------------------
@@ -91,7 +90,7 @@ variables:
 pkg_rpm:
   stage: 'validation'
   tags: ['rpmbuild']
-  <<: *pup_6_18
+  <<: *pup_6_X
   <<: *setup_bundler_env
   script:
     - 'command -v rpmbuild || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
@@ -104,7 +103,7 @@ pkg_rpm:
 #=======================================================================
 
 releng_checks:
-  <<: *pup_5_5_20
+  <<: *pup_6_X
   <<: *setup_bundler_env
   stage: 'validation'
   tags: ['docker']
@@ -117,38 +116,38 @@ releng_checks:
 # Acceptance tests
 # ==============================================================================
 
-pup5.5.20:
-  <<: *pup_5_5_20
+pup_6_X:
+  <<: *pup_6_X
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites'
     - 'bundle exec rake beaker:suites[upgrade,default]'
 
-pup6.18:
-  <<: *pup_6_18
+pup_7_X:
+  <<: *pup_7_X
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites'
     - 'bundle exec rake beaker:suites[upgrade,default]'
 
-pup5.5.20-fips:
-  <<: *pup_5_5_20
+pup6-fips:
+  <<: *pup_6_X
   <<: *acceptance_base
   <<: *only_with_SIMP_FULL_MATRIX
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites'
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[upgrade,default]'
 
-pup5.5.20-oel:
-  <<: *pup_5_5_20
+pup6-oel:
+  <<: *pup_6_X
   <<: *acceptance_base
   <<: *only_with_SIMP_FULL_MATRIX
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
     - 'bundle exec rake beaker:suites[upgrade,oel]'
 
-pup5.5.20-oel-fips:
-  <<: *pup_5_5_20
+pup6-oel-fips:
+  <<: *pup_6_X
   <<: *acceptance_base
   <<: *only_with_SIMP_FULL_MATRIX
   script:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Wed Sep 01 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.11.0-2
+* Wed Sep 01 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.11.0-1
 - Updated source versions to use r10k 3.11.0 and its corresponding gems
 - Update Rakefile task pkg:rpm to add macro brp_mangle_shebangs so the shebangs
   in bash files would be /usr/bin/env ruby instead of pointing to the system ruby.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 * Wed Sep 01 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.11.0-0
-- Updated source versions to use r10k 3.11.0 and its corresponding
+- Updated source versions to use r10k 3.11.0 and its corresponding gems
+- Update Rakefile task pkg:rpm to add macro brp_mangle_shebangs so the shebangs
+  in bash files would be /usr/bin/env ruby instead of pointing to the system ruby.
+- Gem jwt, has a non standard gemspec file name.  Added a check for this so
+  it would build the gem.
 
 * Wed Dec 09 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.7.0-0
 - Changed:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Sep 01 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.11.0-0
+- Updated source versions to use r10k 3.11.0 and its corresponding
+
 * Wed Dec 09 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.7.0-0
 - Changed:
   - Updated source versions to use r10k 3.7.0 and its corresponding

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Wed Sep 01 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.11.0-0
+* Wed Sep 01 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.11.0-2
 - Updated source versions to use r10k 3.11.0 and its corresponding gems
 - Update Rakefile task pkg:rpm to add macro brp_mangle_shebangs so the shebangs
   in bash files would be /usr/bin/env ruby instead of pointing to the system ruby.

--- a/Gemfile
+++ b/Gemfile
@@ -18,11 +18,11 @@ gem_sources.each { |gem_source| source gem_source }
 
 # mandatory gems
 gem 'mg'
-gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~> 5.5')
+gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~> 6.2')
 gem 'rake'
-gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '>= 5.8.1')
+gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.12.1', '< 6'])
 
-gem 'r10k', ENV.fetch('R10K_VERSION', '3.1.1')
+gem 'r10k', ENV.fetch('R10K_VERSION', '3.11')
 gem 'rest-client'
 
 group :testing do
@@ -34,6 +34,6 @@ group :testing do
   gem 'rspec-its'
 
   # A dependency of simp-rake-helpers
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.14.0', '< 2.0'])
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.23.2', '< 2']
 
 end

--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ To update to the latest version of r10k and package all its gems:
    git diff build/sources.yaml
    ```
 
+   To checkout a specifice version run:
+   ```sh
+   bundle exec rake gem_update[<version>]
+   ```
+
+  If you have changed the packaging and need to update the release
+  version for packages already released run
+
+   ```sh
+   R10K_force_release_update=yes bundle exec rake gem_update
+   ```
+  
 2. Verify that the data in `build/sources.yaml` is correct
 
 3. Check out gems and build RPMs using the data in `build/sources.yaml`

--- a/Rakefile
+++ b/Rakefile
@@ -79,11 +79,12 @@ desc <<~DESC
 
   This task will
 DESC
-task :gem_update, [:r10k_version, :update_release] do |_t, args|
+task :gem_update, [:r10k_version] do |_t, args|
 
-  args.with_defaults(:r10k_version => nil, :update_release => false )
+  args.with_defaults(:r10k_version => nil )
   version = args.r10k_version
-  force_release_update = args.update_release
+  update_rel_versions = ENV['R10K_force_release_update'] || false
+  force_release_update = ['yes','y','true','force','update'].include?(update_rel_versions)
 
   new_deps = Marshal.load(Marshal.dump(deps))
   require 'tmpdir'

--- a/Rakefile
+++ b/Rakefile
@@ -166,7 +166,11 @@ namespace :pkg do
       Dir.chdir("src/gems/#{gem}") do |d|
         # multi_json requires a signing key, we don't have one
         sh "sed -i '/signing_key/d' #{gem}.gemspec" if gem == 'multi_json'
-        `gem build --silent #{gem}.gemspec`
+        if gem == 'jwt'
+          `gem build --silent ruby-jwt.gemspec`
+        else
+          `gem build --silent #{gem}.gemspec`
+        end
         FileUtils.mkdir_p 'dist'
         FileUtils.mv Dir.glob('*.gem'), File.join(@rakefile_dir, 'dist')
       end
@@ -219,6 +223,9 @@ namespace :pkg do
     rpm_cmd  = []
     rpm_cmd << 'rpmbuild'
     rpm_cmd << "-D '_topdir #{buildroot}'"
+    # needed on EL8 to disable the aggressive brp_mangle_shebangs script
+    # that results in invalid script shebangs; does nothing in EL7
+    rpm_cmd << "-D '__brp_mangle_shebangs /usr/bin/true'"
     rpm_cmd << '-v -ba build/simp-vendored-r10k.spec'
     sh rpm_cmd.join(' ')
 

--- a/build/sources.yaml
+++ b/build/sources.yaml
@@ -7,99 +7,99 @@ gems:
     license: MIT
     url: https://github.com/ddfreyne/cri
     repo: https://github.com/ddfreyne/cri
-    release: 3
+    release: 1
   faraday:
     version: 0.17.4
     license: MIT
     url: https://lostisland.github.io/faraday
     repo: https://github.com/lostisland/faraday
-    release: 2
+    release: 1
   faraday_middleware:
     version: 0.14.0
     license: MIT
     url: https://github.com/lostisland/faraday_middleware
     repo: https://github.com/lostisland/faraday_middleware
-    release: 3
+    release: 1
   fast_gettext:
     version: 1.1.2
     license: MIT or Ruby
     url: http://github.com/grosser/fast_gettext
     repo: https://github.com/grosser/fast_gettext
-    release: 6
+    release: 4
   gettext:
     version: 3.2.9
     license: Ruby or LGPLv3+
     url: http://ruby-gettext.github.com/
     repo: https://github.com/ruby-gettext/gettext
-    release: 6
+    release: 4
   gettext-setup:
     version: '0.34'
     license: Apache-2.0
     url: https://github.com/puppetlabs/gettext-setup-gem
     repo: https://github.com/puppetlabs/gettext-setup-gem
-    release: 3
+    release: 1
   locale:
     version: 2.1.3
     license: Ruby or LGPLv3+
     url: https://github.com/ruby-gettext/locale
     repo: https://github.com/ruby-gettext/locale
-    release: 3
+    release: 1
   log4r:
     version: 1.1.10
     license: MIT
-    url: https://github.com/colbygk/log4r
+    url: http://log4r.rubyforge.org
     repo: https://github.com/colbygk/log4r
-    release: 7
+    release: 5
   minitar:
     version: '0.9'
     license: Ruby or BSD-2-Clause
     url: https://github.com/halostatue/minitar/
     repo: https://github.com/halostatue/minitar
-    release: 3
+    release: 1
   multi_json:
     version: 1.15.0
     license: MIT
     url: https://github.com/intridea/multi_json
     repo: https://github.com/intridea/multi_json
-    release: 3
+    release: 1
   multipart-post:
     version: 2.1.1
     license: MIT
     url: https://github.com/nicksieger/multipart-post
     repo: https://github.com/nicksieger/multipart-post
-    release: 5
+    release: 3
   puppet_forge:
     version: 2.3.4
     license: Apache-2.0
     url: https://github.com/puppetlabs/forge-ruby
     repo: https://github.com/puppetlabs/forge-ruby
-    release: 3
+    release: 1
   r10k:
     version: 3.11.0
     license: Apache-2.0
     url: https://github.com/puppetlabs/r10k
     repo: https://github.com/puppetlabs/r10k
-    release: 2
+    release: 1
   semantic_puppet:
     version: 1.0.4
     license: Apache-2.0
     url: https://github.com/puppetlabs/semantic_puppet
     repo: https://github.com/puppetlabs/semantic_puppet
-    release: 2
+    release: 1
   text:
     version: 1.3.1
     license: MIT
     url: http://github.com/threedaymonk/text
     repo: http://github.com/threedaymonk/text
-    release: 6
+    release: 4
   colored2:
-    release: 3
+    release: 1
     version: 3.1.2
     license: MIT
     url: http://github.com/kigster/colored2
     repo: https://github.com/kigster/colored2
   jwt:
-    release: 0
+    release: 1
     version: 2.2.3
     license: MIT
     url: https://github.com/jwt/ruby-jwt

--- a/build/sources.yaml
+++ b/build/sources.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.7.0
+version: 3.11.0
 url: https://github.com/simp/pkg-r10k
 gems:
   cri:
@@ -7,9 +7,9 @@ gems:
     license: MIT
     url: https://github.com/ddfreyne/cri
     repo: https://github.com/ddfreyne/cri
-    release: 0
+    release: 1
   faraday:
-    version: 0.17.3
+    version: 0.17.4
     license: MIT
     url: https://lostisland.github.io/faraday
     repo: https://github.com/lostisland/faraday
@@ -19,82 +19,88 @@ gems:
     license: MIT
     url: https://github.com/lostisland/faraday_middleware
     repo: https://github.com/lostisland/faraday_middleware
-    release: 0
+    release: 1
   fast_gettext:
     version: 1.1.2
     license: MIT or Ruby
     url: http://github.com/grosser/fast_gettext
     repo: https://github.com/grosser/fast_gettext
-    release: 3
+    release: 4
   gettext:
     version: 3.2.9
     license: Ruby or LGPLv3+
     url: http://ruby-gettext.github.com/
     repo: https://github.com/ruby-gettext/gettext
-    release: 3
+    release: 4
   gettext-setup:
     version: '0.34'
     license: Apache-2.0
     url: https://github.com/puppetlabs/gettext-setup-gem
     repo: https://github.com/puppetlabs/gettext-setup-gem
-    release: 0
+    release: 1
   locale:
     version: 2.1.3
     license: Ruby or LGPLv3+
     url: https://github.com/ruby-gettext/locale
     repo: https://github.com/ruby-gettext/locale
-    release: 0
+    release: 1
   log4r:
     version: 1.1.10
     license: MIT
-    url: http://log4r.rubyforge.org
+    url: https://github.com/colbygk/log4r
     repo: https://github.com/colbygk/log4r
-    release: 4
+    release: 5
   minitar:
     version: '0.9'
     license: Ruby or BSD-2-Clause
     url: https://github.com/halostatue/minitar/
     repo: https://github.com/halostatue/minitar
-    release: 0
+    release: 1
   multi_json:
     version: 1.15.0
     license: MIT
     url: https://github.com/intridea/multi_json
     repo: https://github.com/intridea/multi_json
-    release: 0
+    release: 1
   multipart-post:
     version: 2.1.1
     license: MIT
     url: https://github.com/nicksieger/multipart-post
     repo: https://github.com/nicksieger/multipart-post
-    release: 2
+    release: 3
   puppet_forge:
     version: 2.3.4
     license: Apache-2.0
     url: https://github.com/puppetlabs/forge-ruby
     repo: https://github.com/puppetlabs/forge-ruby
-    release: 0
+    release: 1
   r10k:
-    version: 3.7.0
+    version: 3.11.0
     license: Apache-2.0
     url: https://github.com/puppetlabs/r10k
     repo: https://github.com/puppetlabs/r10k
     release: 0
   semantic_puppet:
-    version: 1.0.2
+    version: 1.0.4
     license: Apache-2.0
     url: https://github.com/puppetlabs/semantic_puppet
     repo: https://github.com/puppetlabs/semantic_puppet
-    release: 3
+    release: 0
   text:
     version: 1.3.1
     license: MIT
     url: http://github.com/threedaymonk/text
     repo: http://github.com/threedaymonk/text
-    release: 3
+    release: 4
   colored2:
-    release: 0
+    release: 1
     version: 3.1.2
     license: MIT
     url: http://github.com/kigster/colored2
     repo: https://github.com/kigster/colored2
+  jwt:
+    release: 1
+    version: 2.2.3
+    license: MIT
+    url: https://github.com/jwt/ruby-jwt
+    repo: https://github.com/jwt/ruby-jwt

--- a/build/sources.yaml
+++ b/build/sources.yaml
@@ -7,99 +7,99 @@ gems:
     license: MIT
     url: https://github.com/ddfreyne/cri
     repo: https://github.com/ddfreyne/cri
-    release: 1
+    release: 3
   faraday:
     version: 0.17.4
     license: MIT
     url: https://lostisland.github.io/faraday
     repo: https://github.com/lostisland/faraday
-    release: 0
+    release: 2
   faraday_middleware:
     version: 0.14.0
     license: MIT
     url: https://github.com/lostisland/faraday_middleware
     repo: https://github.com/lostisland/faraday_middleware
-    release: 1
+    release: 3
   fast_gettext:
     version: 1.1.2
     license: MIT or Ruby
     url: http://github.com/grosser/fast_gettext
     repo: https://github.com/grosser/fast_gettext
-    release: 4
+    release: 6
   gettext:
     version: 3.2.9
     license: Ruby or LGPLv3+
     url: http://ruby-gettext.github.com/
     repo: https://github.com/ruby-gettext/gettext
-    release: 4
+    release: 6
   gettext-setup:
     version: '0.34'
     license: Apache-2.0
     url: https://github.com/puppetlabs/gettext-setup-gem
     repo: https://github.com/puppetlabs/gettext-setup-gem
-    release: 1
+    release: 3
   locale:
     version: 2.1.3
     license: Ruby or LGPLv3+
     url: https://github.com/ruby-gettext/locale
     repo: https://github.com/ruby-gettext/locale
-    release: 1
+    release: 3
   log4r:
     version: 1.1.10
     license: MIT
     url: https://github.com/colbygk/log4r
     repo: https://github.com/colbygk/log4r
-    release: 5
+    release: 7
   minitar:
     version: '0.9'
     license: Ruby or BSD-2-Clause
     url: https://github.com/halostatue/minitar/
     repo: https://github.com/halostatue/minitar
-    release: 1
+    release: 3
   multi_json:
     version: 1.15.0
     license: MIT
     url: https://github.com/intridea/multi_json
     repo: https://github.com/intridea/multi_json
-    release: 1
+    release: 3
   multipart-post:
     version: 2.1.1
     license: MIT
     url: https://github.com/nicksieger/multipart-post
     repo: https://github.com/nicksieger/multipart-post
-    release: 3
+    release: 5
   puppet_forge:
     version: 2.3.4
     license: Apache-2.0
     url: https://github.com/puppetlabs/forge-ruby
     repo: https://github.com/puppetlabs/forge-ruby
-    release: 1
+    release: 3
   r10k:
     version: 3.11.0
     license: Apache-2.0
     url: https://github.com/puppetlabs/r10k
     repo: https://github.com/puppetlabs/r10k
-    release: 0
+    release: 2
   semantic_puppet:
     version: 1.0.4
     license: Apache-2.0
     url: https://github.com/puppetlabs/semantic_puppet
     repo: https://github.com/puppetlabs/semantic_puppet
-    release: 0
+    release: 2
   text:
     version: 1.3.1
     license: MIT
     url: http://github.com/threedaymonk/text
     repo: http://github.com/threedaymonk/text
-    release: 4
+    release: 6
   colored2:
-    release: 1
+    release: 3
     version: 3.1.2
     license: MIT
     url: http://github.com/kigster/colored2
     repo: https://github.com/kigster/colored2
   jwt:
-    release: 1
+    release: 0
     version: 2.2.3
     license: MIT
     url: https://github.com/jwt/ruby-jwt

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -13,6 +13,13 @@ HOSTS:
     box: centos/7
     hypervisor: <%= hypervisor %>
 
+  el8:
+    roles:
+      - client
+    platform: el-8-x86_64
+    box: generic/centos8
+    hypervisor: <%= hypervisor %>
+
 CONFIG:
   log_level: verbose
   synced_folder : disabled

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -10,7 +10,14 @@ HOSTS:
     roles:
       - client
     platform: el-7-x86_64
-    box: onyxpoint/oel-7-x86_64
+    box: generic/oracle7
+    hypervisor: <%= hypervisor %>
+
+  el8:
+    roles:
+      - client
+    platform: el-8-x86_64
+    box: generic/oracle8
     hypervisor: <%= hypervisor %>
 
 CONFIG:

--- a/spec/acceptance/suites/upgrade/upgrade_r10k_spec.rb
+++ b/spec/acceptance/suites/upgrade/upgrade_r10k_spec.rb
@@ -31,28 +31,36 @@ test_name 'upgrade simp vendored r10k'
 describe 'upgrade simp vendored r10k' do
 
   hosts.each do |host|
+
     let(:dist_dir) { File.join(File.dirname(__FILE__), '../../../../dist/') }
 
     let(:expected_version) {  %x{rpm -qp "#{dist_dir}/simp-vendored-r10k-gem-r10k*.rpm" --info | grep Version}.split(':')[1].strip }
 
     osmajver = fact_on(host, 'operatingsystemmajrelease')
 
-    context 'install simp_vendored r10k from simp deps repo' do
-      it 'should install repos ' do
-        install_deps(host, osmajver)
-        simp_deps_repo(host)
-        on(host, 'yum install -y simp-vendored-r10k')
-        on(host, '/usr/share/simp/bin/r10k')
+    context "install simp_vendored r10k from simp deps repo on el#{osmajver}" do
+
+      it "should install repos" do
+        if osmajver >= '8'
+          skip("Can't run this test on EL8 until the EL8 simp erpos get setup")
+        else
+          install_deps(host, osmajver)
+          simp_deps_repo(host)
+          on(host, 'yum install -y simp-vendored-r10k')
+          on(host, 'echo "run r10k first time";/usr/share/simp/bin/r10k version')
+        end
       end
 
-      it 'should install and run the new version r10k' do
-        create_repo(host, '/rpms', dist_dir)
-        on(host, 'yum update -y --nogpgcheck')
-        result = on(host, '/usr/share/simp/bin/r10k version').stdout
-        expect(result.strip).to eq("r10k #{expected_version}")
+      it "should install and run the new version r10k" do
+        if osmajver >= '8'
+          skip("Can't run this test on EL8 until the EL8 simp erpos get setup")
+        else
+          create_repo(host, '/rpms', dist_dir)
+          on(host, 'yum update -y --nogpgcheck')
+          result = on(host, '/usr/share/simp/bin/r10k version').stdout
+          expect(result.strip).to eq("r10k #{expected_version}")
+        end
       end
-
     end
-
   end
 end

--- a/spec/acceptance/suites/upgrade/upgrade_r10k_spec.rb
+++ b/spec/acceptance/suites/upgrade/upgrade_r10k_spec.rb
@@ -42,7 +42,7 @@ describe 'upgrade simp vendored r10k' do
 
       it "should install repos" do
         if osmajver >= '8'
-          skip("Can't run this test on EL8 until the EL8 simp erpos get setup")
+          skip("Can't run this test on EL8 until the EL8 simp repos get setup")
         else
           install_deps(host, osmajver)
           simp_deps_repo(host)
@@ -53,7 +53,7 @@ describe 'upgrade simp vendored r10k' do
 
       it "should install and run the new version r10k" do
         if osmajver >= '8'
-          skip("Can't run this test on EL8 until the EL8 simp erpos get setup")
+          skip("Can't run this test on EL8 until the EL8 simp repos get setup")
         else
           create_repo(host, '/rpms', dist_dir)
           on(host, 'yum update -y --nogpgcheck')


### PR DESCRIPTION
    - This module has its own pkg:rpm task in its rake file.  Needed to
      add the correct macro to disable brp_mangle_shebangs.
    - Updated the version of r10k to 3.11.0 and  rebuilt the
      build/sources.yaml file.
    - New gem dependency, jwt, has a gemspec file called ruby-jwt.gemspec.
      Needed to add an exception into the rake task that builds the gems to
      look for the non-standard name of the gemspec file.
    
    SIMP-10445 #close
