### PR TITLE
(SIMP-10615) colored2 RPM obsoletes colored RPMs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Mon Oct 25 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.12.1-3
+- Changed:
+  - RPM for `colored2` gem now obsoletes RPMs for older `colored` gem
+- Added:
+  - New `sources.yaml` keys for arbitrary `obsoletes`, `requires`,
+    `conflicts`, and `provides`
+
 * Sun Oct 24 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.12.1-2
 - Changed:
   - Release tag bump to account for ISO-related fixes

--- a/build/simp-vendored-r10k.spec
+++ b/build/simp-vendored-r10k.spec
@@ -13,7 +13,7 @@
 Summary: r10k with puppet-safe gem installation
 Name: simp-vendored-r10k
 Version: %{r10k_version}
-Release: 2%{?dist}
+Release: 3%{?dist}
 Group: Development/Languages
 License: Apache-2.0
 URL: https://github.com/simp/pkg-r10k
@@ -63,7 +63,7 @@ in your path by default.
 %package doc
 Summary: Documentation for the SIMP r10k installation
 Version: %{r10k_version}
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: Apache-2.0
 URL: https://github.com/simp/pkg-r10k
 BuildArch: noarch
@@ -244,7 +244,7 @@ Gem dependency for %{name}
 %package gem-r10k
 Summary: A r10k Gem for use with %{name}
 Version: 3.12.1
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: Apache-2.0
 URL: https://github.com/puppetlabs/r10k
 Source23: r10k-3.12.1.gem
@@ -286,12 +286,13 @@ Gem dependency for %{name}
 %package gem-colored2
 Summary: A colored2 Gem for use with %{name}
 Version: 3.1.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: MIT
 URL: http://github.com/kigster/colored2
 Source26: colored2-3.1.2.gem
 BuildArch: noarch
 Provides: rubygem(%{pkgname}-colored2) = 3.1.2
+Obsoletes: simp-vendored-r10k-gem-colored < 2.0
 
 %description gem-colored2
 

--- a/build/simp-vendored-r10k.spec.erb
+++ b/build/simp-vendored-r10k.spec.erb
@@ -70,6 +70,12 @@ URL: <%= data['url'] %>
 Source<%= source %>: <%= dep %>-<%= data['version'] %>.gem
 BuildArch: noarch
 Provides: rubygem(%{pkgname}-<%= dep %>) = <%= data['version'] %>
+<% ['Provides', 'Requires', 'Conflicts', 'Obsoletes'].each do |dep_type|
+  (data[dep_type.downcase] || []).each do |item|
+-%>
+<%= dep_type %>: <%= item %>
+<% end
+end -%>
 
 %description gem-<%= dep %>
 

--- a/build/sources.yaml
+++ b/build/sources.yaml
@@ -81,7 +81,7 @@ gems:
     license: Apache-2.0
     url: https://github.com/puppetlabs/r10k
     repo: https://github.com/puppetlabs/r10k
-    release: 2
+    release: 3
   semantic_puppet:
     version: 1.0.4
     license: Apache-2.0
@@ -95,11 +95,13 @@ gems:
     repo: http://github.com/threedaymonk/text
     release: 4
   colored2:
-    release: 1
+    release: 2
     version: 3.1.2
     license: MIT
     url: http://github.com/kigster/colored2
     repo: https://github.com/kigster/colored2
+    obsoletes:
+      - 'simp-vendored-r10k-gem-colored < 2.0'
   jwt:
     release: 1
     version: 2.2.3


### PR DESCRIPTION
* Changed:
  - RPM for `colored2` gem now obsoletes RPMs for older `colored` gem

* Added:
  - New `sources.yaml` keys for arbitrary `obsoletes`, `requires`,
    `conflicts`, and `provides`

[SIMP-10615] #close

[SIMP-10615]: https://simp-project.atlassian.net/browse/SIMP-10615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ