### PR TITLE
(SIMP-MAINT) Include all RPMs in `dist/`

### DIFF
--- a/.github/workflows/tag_deploy_github-rpms.yml
+++ b/.github/workflows/tag_deploy_github-rpms.yml
@@ -1,4 +1,4 @@
-# When a SemVer tag is pushed, create GitHub release & trigger RPM build
+# Deploy GitHub release when a SemVer tag is pushed, trigger el7 + el8 RPM build
 # ------------------------------------------------------------------------------
 #
 #             NOTICE: **This file is maintained with puppetsync**
@@ -36,9 +36,6 @@ on:
       #   https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
       - '[0-9]+\.[0-9]+\.[0-9]+'
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
-
-env:
-  PUPPET_VERSION: '~> 6'
 
 jobs:
   create-github-release:
@@ -107,7 +104,7 @@ jobs:
       - name: Get tag & annotation info (${{github.ref}})
         id: tag-check
         run: echo "::set-output name=tag::${GITHUB_REF/refs\/tags\//}"
-      - name: Trigger RPM release workflow
+      - name: Trigger RPM release workflow (el7)
         uses: actions/github-script@v4
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -122,8 +119,34 @@ jobs:
               workflow_id: 'release_rpms.yml',
               ref: process.env.DEFAULT_BRANCH,
               inputs: {
-                release_tag: process.env.TARGET_TAG
+                release_tag: process.env.TARGET_TAG,
+                clean: 'no',
+                clobber: 'yes',
+                build_container_os: 'centos7'
               }
-            }).then( (result) => {
-              console.log( `== Submitted workflow dispatch: status ${result.status}` )
+            }).then((result) => {
+              console.log( `== Submitted workflow dispatch to build RPMs from el7: status ${result.status}` )
+            })
+      - name: Trigger RPM release workflow (el8)
+        uses: actions/github-script@v4
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          TARGET_TAG: ${{ steps.tag-check.outputs.tag }}
+        with:
+          github-token: ${{ secrets.SIMP_AUTO_GITHUB_TOKEN__REPO_SCOPE }}
+          script: |
+            const [owner, repo] = process.env.TARGET_REPO.split('/')
+            await github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
+              owner: owner,
+              repo: repo,
+              workflow_id: 'release_rpms.yml',
+              ref: process.env.DEFAULT_BRANCH,
+              inputs: {
+                release_tag: process.env.TARGET_TAG,
+                clean: 'no',
+                clobber: 'yes',
+                build_container_os: 'centos8'
+              }
+            }).then((result) => {
+              console.log( `== Submitted workflow dispatch to build RPMs from el8: status ${result.status}` )
             })

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Wed Feb 09 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.12.1-4
+- Fixed:
+  - SRPMs are now copied into `dist/` during builds
+
+
 * Mon Oct 25 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.12.1-3
 - Changed:
   - RPM for `colored2` gem now obsoletes RPMs for older `colored` gem

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,6 @@
 - Fixed:
   - SRPMs are now copied into `dist/` during builds
 
-
 * Mon Oct 25 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.12.1-3
 - Changed:
   - RPM for `colored2` gem now obsoletes RPMs for older `colored` gem

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To update to the latest version of r10k and package all its gems:
    git diff build/sources.yaml
    ```
 
-   To checkout a specifice version run:
+   To checkout a specific version, run:
    ```sh
    bundle exec rake gem_update[<version>]
    ```
@@ -64,7 +64,7 @@ To update to the latest version of r10k and package all its gems:
    ```sh
    R10K_force_release_update=yes bundle exec rake gem_update
    ```
-  
+
 2. Verify that the data in `build/sources.yaml` is correct
 
 3. Check out gems and build RPMs using the data in `build/sources.yaml`

--- a/Rakefile
+++ b/Rakefile
@@ -233,7 +233,7 @@ namespace :pkg do
     src_cmd  = []
     src_cmd << 'rpmbuild'
     src_cmd << "-D '_topdir #{buildroot}'"
-    src_cmd << '-v -v -v -bs build/simp-vendored-r10k.spec'
+    src_cmd << '-v -bs build/simp-vendored-r10k.spec'
     STDERR.puts "== #{src_cmd.join(' ')}"
     sh src_cmd.join(' ')
 
@@ -243,14 +243,14 @@ namespace :pkg do
     # needed on EL8 to disable the aggressive brp_mangle_shebangs script
     # that results in invalid script shebangs; does nothing in EL7
     rpm_cmd << "-D '__brp_mangle_shebangs /usr/bin/true'"
-    rpm_cmd << '-v -v -v -ba build/simp-vendored-r10k.spec'
+    rpm_cmd << '-v -ba build/simp-vendored-r10k.spec'
 
     STDERR.puts "== #{rpm_cmd.join(' ')}"
     ::Bundler.send(CLEAN_ENV_METHOD) do
       sh rpm_cmd.join(' ')
     end
 
-    FileUtils.cp Dir.glob('dist/RPMBUILD/RPMS/noarch/*.rpm'), 'dist'
+    FileUtils.cp Dir.glob('dist/RPMBUILD/{SRPMS/*.rpm,RPMS/*/*.rpm}'), 'dist'
 
     # Needed for the ISO build
     require 'simp/rpm'

--- a/build/simp-vendored-r10k.spec
+++ b/build/simp-vendored-r10k.spec
@@ -480,6 +480,18 @@ EOM
 
 
 %changelog
+* Wed Feb 09 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.12.1-4
+- Fixed:
+  - SRPMs are now copied into `dist/` during builds
+
+
+* Mon Oct 25 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.12.1-3
+- Changed:
+  - RPM for `colored2` gem now obsoletes RPMs for older `colored` gem
+- Added:
+  - New `sources.yaml` keys for arbitrary `obsoletes`, `requires`,
+    `conflicts`, and `provides`
+
 * Sun Oct 24 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.12.1-2
 - Changed:
   - Release tag bump to account for ISO-related fixes

--- a/build/simp-vendored-r10k.spec
+++ b/build/simp-vendored-r10k.spec
@@ -484,7 +484,6 @@ EOM
 - Fixed:
   - SRPMs are now copied into `dist/` during builds
 
-
 * Mon Oct 25 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.12.1-3
 - Changed:
   - RPM for `colored2` gem now obsoletes RPMs for older `colored` gem

--- a/build/sources.yaml
+++ b/build/sources.yaml
@@ -81,7 +81,7 @@ gems:
     license: Apache-2.0
     url: https://github.com/puppetlabs/r10k
     repo: https://github.com/puppetlabs/r10k
-    release: 3
+    release: 4
   semantic_puppet:
     version: 1.0.4
     license: Apache-2.0


### PR DESCRIPTION
This patch ensures that:

* SRPMs are now copied into `dist/` during `pkg:rpm` builds
* RPMs other than `noarch` are copied into `dist/` 
* GHA release build both EL7 and EL8 RPMs