### PR TITLE
Remove puppet 6 from .gitlab-ci.yml

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, reopened, synchronize]
 
 env:
-  PUPPET_VERSION: '~> 6'
+  PUPPET_VERSION: '~> 7'
 
 jobs:
   yaml-syntax:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -222,19 +222,19 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_6_x: &pup_6_x
-  image: 'ruby:2.5'
-  variables:
-    PUPPET_VERSION: '~> 6.0'
-    BEAKER_PUPPET_COLLECTION: 'puppet6'
-    MATRIX_RUBY_VERSION: '2.5'
-
 .pup_7_x: &pup_7_x
   image: 'ruby:2.7'
   variables:
     PUPPET_VERSION: '~> 7.0'
     BEAKER_PUPPET_COLLECTION: 'puppet7'
     MATRIX_RUBY_VERSION: '2.7'
+
+.pup_8_x: &pup_8_x
+  image: 'ruby:3.2'
+  variables:
+    PUPPET_VERSION: '~> 8.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet8'
+    MATRIX_RUBY_VERSION: '3.2'
 
 # Testing Environments
 #-----------------------------------------------------------------------
@@ -275,7 +275,7 @@ variables:
 pkg_rpm:
   stage: 'validation'
   tags: ['rpmbuild']
-  <<: *pup_6_x
+  <<: *pup_7_x
   <<: *setup_bundler_env
   script:
     - 'command -v rpmbuild || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
@@ -288,7 +288,7 @@ pkg_rpm:
 #=======================================================================
 
 releng_checks:
-  <<: *pup_6_x
+  <<: *pup_7_x
   <<: *setup_bundler_env
   stage: 'validation'
   tags: ['docker']
@@ -301,34 +301,14 @@ releng_checks:
 # Acceptance tests
 # ==============================================================================
 
-pup_6_x:
-  <<: *pup_6_x
+pup7.x:
+  <<: *pup_7_x
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,default]'
 
-pup_6_x-upgrade:
-  <<: *pup_6_x
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites[upgrade,default]'
-
-pup_7_x:
+pup7.x-fips:
   <<: *pup_7_x
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake clean'
-    - 'bundle exec rake beaker:suites[default,default]'
-
-pup_7_x-upgrade:
-  <<: *pup_7_x
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake clean'
-    - 'bundle exec rake beaker:suites[upgrade,default]'
-
-pup6.x-fips:
-  <<: *pup_6_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
@@ -336,8 +316,8 @@ pup6.x-fips:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[upgrade,default]'
 
-pup6.x-oel:
-  <<: *pup_6_x
+pup7.x-oel:
+  <<: *pup_7_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
@@ -345,11 +325,31 @@ pup6.x-oel:
     - 'bundle exec rake beaker:suites[default,oel]'
     - 'bundle exec rake beaker:suites[upgrade,oel]'
 
-pup6.x-oel-fips:
-  <<: *pup_6_x
+pup7.x-oel-fips:
+  <<: *pup_7_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake clean'
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[upgrade,oel]'
+
+pup7.x-upgrade:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[upgrade,default]'
+
+pup8.x:
+  <<: *pup_8_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake clean'
+    - 'bundle exec rake beaker:suites[default,default]'
+
+pup8.x-upgrade:
+  <<: *pup_8_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake clean'
+    - 'bundle exec rake beaker:suites[upgrade,default]'

--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,9 @@ gem_sources.each { |gem_source| source gem_source }
 
 # mandatory gems
 gem 'mg'
-gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~> 6.2')
+gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~> 7')
 gem 'rake'
-gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.12.1', '< 6'])
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']
 
 gem 'r10k', ENV.fetch('R10K_VERSION', '3.11')
 gem 'rest-client'
@@ -34,6 +34,19 @@ group :testing do
   gem 'rspec-its'
 
   # A dependency of simp-rake-helpers
-  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.23.2', '< 2']
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.28.0', '< 2']
 
+end
+
+# Evaluate extra gemfiles if they exist
+extra_gemfiles = [
+  ENV['EXTRA_GEMFILE'] || '',
+  "#{__FILE__}.project",
+  "#{__FILE__}.local",
+  File.join(Dir.home, '.gemfile'),
+]
+extra_gemfiles.each do |gemfile|
+  if File.file?(gemfile) && File.readable?(gemfile)
+    eval(File.read(gemfile), binding)
+  end
 end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -2,25 +2,23 @@
 HOSTS:
   el7:
     roles:
-      - client
+    - client
     platform: el-7-x86_64
     box: centos/7
     hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
     family: centos-cloud/centos-7
     gce_machine_type: n1-standard-2
-
   el8:
     roles:
-      - client
+    - client
     platform: el-8-x86_64
     box: generic/centos8
     hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
     family: centos-cloud/centos-stream-8
     gce_machine_type: n1-standard-2
-
 CONFIG:
   log_level: verbose
-  synced_folder : disabled
+  synced_folder: disabled
   type: aio
   vagrant_memsize: 256
   puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -1,30 +1,24 @@
-<%
-  if ENV['BEAKER_HYPERVISOR']
-    hypervisor = ENV['BEAKER_HYPERVISOR']
-  else
-    hypervisor = 'vagrant'
-  end
--%>
+---
 HOSTS:
   el7:
     roles:
-      - client
+    - client
     platform: el-7-x86_64
     box: generic/oracle7
-    hypervisor: <%= hypervisor %>
-
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-7
+    gce_machine_type: n1-standard-2
   el8:
     roles:
-      - client
+    - client
     platform: el-8-x86_64
     box: generic/oracle8
-    hypervisor: <%= hypervisor %>
-
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-8
+    gce_machine_type: n1-standard-2
 CONFIG:
   log_level: verbose
-  synced_folder : disabled
+  synced_folder: disabled
   type: aio
   vagrant_memsize: 256
-<% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
-  puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
-<% end -%>
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"


### PR DESCRIPTION
:warning: This was a PoC hand-edited change from 20230501

This patch moves puppet 6 refs to 7, puppet 7 refs to 8 and comments 
out the puppet 8 and oel refs in the "repo specific content" section.

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.